### PR TITLE
Fix allocation cleanup in FreeDialogResult

### DIFF
--- a/UI/addinui.cpp
+++ b/UI/addinui.cpp
@@ -162,20 +162,19 @@ namespace ui::addinui
 	__declspec(dllexport) void __cdecl FreeDialogResult(_In_ LPADDINDIALOGRESULT lpDialogResult)
 	{
 		if (lpDialogResult)
+		{
+			if (lpDialogResult->lpDialogControlResults)
 			{
-				if (lpDialogResult->lpDialogControlResults)
+				for (ULONG i = 0; i < lpDialogResult->ulNumControls; i++)
 				{
-					for (ULONG i = 0; i < lpDialogResult->ulNumControls; i++)
-					{
-						delete[] lpDialogResult->lpDialogControlResults[i].lpBin;
-						delete[] lpDialogResult->lpDialogControlResults[i].szText;
-					}
-
-					delete[] lpDialogResult->lpDialogControlResults;
+					delete[] lpDialogResult->lpDialogControlResults[i].lpBin;
+					delete[] lpDialogResult->lpDialogControlResults[i].szText;
 				}
-
-				delete lpDialogResult;
 			}
+
+			delete[] lpDialogResult->lpDialogControlResults;
+			delete lpDialogResult;
+		}
 	}
 
 	// Adds menu items appropriate to the context

--- a/UI/addinui.cpp
+++ b/UI/addinui.cpp
@@ -162,18 +162,20 @@ namespace ui::addinui
 	__declspec(dllexport) void __cdecl FreeDialogResult(_In_ LPADDINDIALOGRESULT lpDialogResult)
 	{
 		if (lpDialogResult)
-		{
-			if (lpDialogResult->lpDialogControlResults)
 			{
-				for (ULONG i = 0; i < lpDialogResult->ulNumControls; i++)
+				if (lpDialogResult->lpDialogControlResults)
 				{
-					delete[] lpDialogResult->lpDialogControlResults[i].lpBin;
-					delete[] lpDialogResult->lpDialogControlResults[i].szText;
-				}
-			}
+					for (ULONG i = 0; i < lpDialogResult->ulNumControls; i++)
+					{
+						delete[] lpDialogResult->lpDialogControlResults[i].lpBin;
+						delete[] lpDialogResult->lpDialogControlResults[i].szText;
+					}
 
-			delete[] lpDialogResult;
-		}
+					delete[] lpDialogResult->lpDialogControlResults;
+				}
+
+				delete lpDialogResult;
+			}
 	}
 
 	// Adds menu items appropriate to the context


### PR DESCRIPTION
This change corrects the cleanup logic in FreeDialogResult.

Replace delete[] with delete when destroying _AddInDialogResult, matching its allocation with scalar new.
Release the lpDialogControlResults array after freeing the dynamically allocated members it contains.

These changes make the allocation/deallocation pairs consistent and ensure the dialog result object is fully cleaned up.